### PR TITLE
Add external usage proofs section to river usage page

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,80 @@
+# Salinas River Recreation Guide
+
+A bilingual (English/Spanish) static site built with Eleventy 3 and WebC components. The site helps people find access points, plan paddling trips, check water conditions, and view photos of the Salinas River in Central California.
+
+## Core Principles
+
+1. **All changes must support both English and Spanish.** Every user-facing string must use the i18n system. Never hardcode English text in templates.
+2. **WCAG 2 AA compliance is required.** Use semantic HTML, ARIA labels, sufficient color contrast, keyboard navigability, and accessible form controls.
+3. **Prioritize usability.** The site serves real people trying to safely access the river. Clarity and simplicity over cleverness.
+
+## Tech Stack
+
+- **Eleventy 3** with TypeScript config (`eleventy.config.ts`)
+- **WebC** for components (`src/_components/`)
+- **i18next** for translations (`src/_data/locales/en.json`, `es.json`)
+- **Leaflet 2** for interactive maps
+- **Sass** for styling (scoped in WebC `<style>` blocks)
+- **Pagefind** for client-side search
+
+## Internationalization
+
+Translation files live in `src/_data/locales/en.json` and `src/_data/locales/es.json`. The i18n system is defined in `src/_lib/i18n/filters.ts`.
+
+### Key filters (available in all WebC templates)
+
+- `t(key)` - Translate a string key for the current page language. Usage: `@text="t('accessPoints')"` or `@raw="t('footer.by')"` for HTML content.
+- `u(path)` - Prefix a URL path with the current language. Usage: `:href="u('/access-points/')"` outputs `/en/access-points/` or `/es/access-points/`.
+- `l(object, value)` - Get a localized value from a `translate` object in data files. Usage: `@text="l(point.translate, 'title')"` reads `point.translate.en.title` or `point.translate.es.title`.
+- `formatDate(dateStr)`, `formatDateTime(dateStr)`, `formatNumber(value)` - Locale-aware formatting.
+- `switchLanguagePath()` - Generate URL to the same page in the other language.
+
+### Adding new strings
+
+1. Add the key to both `en.json` and `es.json`
+2. Use `t('key')` in templates
+3. For data files (access points, trips), add translations under `translate.en` and `translate.es`
+
+### Page structure
+
+English and Spanish pages mirror each other under `src/en/` and `src/es/`. Each page sets `lang` in its front matter. Dynamic pages (access points, trips) use Eleventy pagination with `permalink` functions that include the language prefix.
+
+## Project Structure
+
+```
+src/
+  _components/
+    common/       # Reusable components (flow-badge, flood-warning, etc.)
+    layout/       # Header, footer, global styles
+    pages/        # Page-level components
+  _data/
+    locales/      # en.json, es.json translation files
+    accessPoints/ # JSON files per access point
+    trips/        # JSON files per trip
+    images/       # Source photos
+  _includes/      # Layouts (base.webc, default.webc)
+  _js/            # Client-side JS (maps, interactivity)
+  _lib/           # Build-time code
+    i18n/         # i18next init and filters
+    data/         # Data processing (gauges, photos, maps)
+  en/             # English pages
+  es/             # Spanish pages (mirrors en/)
+  assets/         # Static assets
+```
+
+## Data Model
+
+- **Access points**: JSON files in `src/_data/accessPoints/`. Include lat/lon, county, gauge association, flow recommendations, GeoJSON directions, ADA accessibility, and bilingual translate blocks.
+- **Trips**: JSON files in `src/_data/trips/`. Include route as GeoJSON LineString, put-in/take-out points, and bilingual translate blocks.
+- **Gauges**: Fetched from USGS at build time (`src/_lib/data/fetch-gauges.ts`). Six stations with real-time flow (cfs) and height data.
+
+## Commands
+
+- `npm run dev` - Start dev server (Eleventy with `--serve`)
+- `npm run build` - Full build (Eleventy + Pagefind indexing)
+
+## Style Conventions
+
+- CSS variables are defined in `src/_components/layout/site-styles.webc`
+- Component styles are scoped inside each `.webc` file's `<style>` block
+- Key colors: `--main-blue: #0050b8`, `--light-blue: #bde2e8`

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "eleventy-dev",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["tsx", "./node_modules/.bin/eleventy", "--config=eleventy.config.ts", "--serve", "--port=8082"],
+      "port": 8082,
+      "autoPort": false
+    }
+  ]
+}

--- a/src/_components/layout/site-styles.webc
+++ b/src/_components/layout/site-styles.webc
@@ -21,6 +21,10 @@
     --main-blue-secondary: #43a7ff;
   }
 
+  body {
+    background-color: #ffffff;
+  }
+
   a {
     color: var(--link-color);
   }

--- a/src/_components/pages/page-usage.webc
+++ b/src/_components/pages/page-usage.webc
@@ -1,5 +1,23 @@
 <h1 @text="t('usage.title')"></h1>
 
+<section webc:if="externalUsageProofs && externalUsageProofs.length">
+  <h2 @text="t('usage.externalWebsites')"></h2>
+  <ul class="external-links">
+    <li webc:for="proof of [...externalUsageProofs].sort((a, b) => new Date(b.date) - new Date(a.date))">
+      <a :href="proof.url" class="external-proof-link" target="_blank" rel="noopener" @text="l(proof.translate, 'name')"></a>
+      <span class="external-date" webc:if="proof.date" @text="formatDate(proof.date)"></span>
+      <span class="external-access-points" webc:if="proof.accessPoints && proof.accessPoints.length">
+        <span @text="t('usage.externalWebsitesNearAccessPoints')" webc:nokeep></span>
+        <span webc:for="slug of proof.accessPoints" webc:nokeep><a class="external-access-point-link" :href="u(`/access-points/${slug}/`)" @text="l(accessPoints[slug].translate, 'title')"></a></span>
+      </span>
+      <span class="external-trips" webc:if="proof.trips && proof.trips.length">
+        <span @text="t('usage.externalWebsitesRelatedTrips')" webc:nokeep></span>
+        <span webc:for="slug of proof.trips" webc:nokeep><a class="external-trip-link" :href="u(`/trips/${slug}/`)" @text="l(trips[slug].translate, 'title')"></a></span>
+      </span>
+    </li>
+  </ul>
+</section>
+
 <section webc:if="usagePhotos && usagePhotos.length">
   <h2 @text="t('usage.photosTitle')"></h2>
   <p @text="t('usage.photosPreamble')"></p>
@@ -65,6 +83,37 @@
 <style>
   section {
     margin-bottom: 3rem;
+  }
+
+  .external-links {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+
+    li {
+      display: flex;
+      flex-direction: column;
+      gap: 0.15rem;
+    }
+
+    .external-date {
+      font-size: 0.875rem;
+      color: #555;
+    }
+
+    .external-access-points,
+    .external-trips {
+      font-size: 0.875rem;
+      color: #555;
+
+      .external-access-point-link + .external-access-point-link::before,
+      .external-trip-link + .external-trip-link::before {
+        content: ", ";
+      }
+    }
   }
 
   .photo-grid,

--- a/src/_data/external-usage-proofs.json
+++ b/src/_data/external-usage-proofs.json
@@ -1,0 +1,102 @@
+[
+  {
+    "url": "https://thesqueakypedal.com/2026/03/02/floating-the-salinas-atascadero-paso-robles/",
+    "date": "2026-03-02",
+    "accessPoints": ["atascadero-de-anza-sycamore", "gabarda-de-anza-trail"],
+    "translate": {
+      "en": {
+        "name": "Portage: Floating the Salinas River Between Atascadero and Paso Robles"
+      },
+      "es": {
+        "name": "Portage: Flotando el río Salinas entre Atascadero y Paso Robles"
+      }
+    }
+  },
+  {
+    "url": "https://oag.ca.gov/system/files/opinions/pdfs/80-815.pdf",
+    "date": "1981-06-09",
+    "accessPoints": ["bradley"],
+    "trips": ["bradley-bradley"],
+    "translate": {
+      "en": {
+        "name": "Legal complaint about people tubing the Salinas near Bradley"
+      },
+      "es": {
+        "name": "Denuncia legal sobre personas haciendo tubing en el Salinas cerca de Bradley"
+      }
+    }
+  },
+  {
+    "url": "https://www.montereycountynow.com/people/831/a-group-of-professionals-and-a-disheveled-writer-paddle-down-the-salinas-river-in-south/article_6959f460-056b-11ee-a24c-575a46271b12.html",
+    "date": "2023-06-08",
+    "accessPoints": ["san-ardo", "san-lucas"],
+    "trips": ["san-ardo-san-lucas"],
+    "translate": {
+      "en": {
+        "name": "Monterey County Now: Wildlife photographers Frans Lanting and Christine Eckstrom paddle 10 miles from San Ardo to San Lucas, documenting bald eagles and beavers along the Salinas River"
+      },
+      "es": {
+        "name": "Monterey County Now: Los fotógrafos de vida silvestre Frans Lanting y Christine Eckstrom reman 10 millas desde San Ardo hasta San Lucas, documentando águilas calvas y castores a lo largo del río Salinas"
+      }
+    }
+  },
+  {
+    "url": "https://www.montereycountynow.com/archives/2014/0807/traveling-the-150-mile-span-of-the-salinas-river-yields-lessons-on-the-valley-versus/article_d2e3f1e8-1db6-11e4-8f95-001a4bcf6878.html",
+    "date": "2014-08-07",
+    "translate": {
+      "en": {
+        "name": "Monterey County Now: Traveling the 150-mile span of the Salinas River, documenting recreational use and water rights discussions"
+      },
+      "es": {
+        "name": "Monterey County Now: Recorriendo los 150 millas del río Salinas, documentando el uso recreativo y las discusiones sobre derechos de agua"
+      }
+    }
+  },
+  {
+    "url": "http://brt-insights.blogspot.com/2009/08/salinas-river-california-whitewater.html",
+    "date": "2009-08-01",
+    "accessPoints": ["atascadero-de-anza-sycamore", "bradley", "san-ardo"],
+    "trips": ["bradley-san-ardo"],
+    "translate": {
+      "en": {
+        "name": "BRT Insights: Detailed kayaking and whitewater guide for the Salinas River with sections from Santa Margarita to Atascadero (Class I/II), Camp Roberts to Bradley (Class I), and Bradley to San Ardo (Class I+)"
+      },
+      "es": {
+        "name": "BRT Insights: Guía detallada de kayak y aguas bravas del río Salinas con secciones desde Santa Margarita a Atascadero (Clase I/II), Camp Roberts a Bradley (Clase I) y Bradley a San Ardo (Clase I+)"
+      }
+    }
+  },
+  {
+    "url": "https://calflyfisher.com/destinations/the-salinas-river-watershed/",
+    "translate": {
+      "en": {
+        "name": "California Fly Fisher: Fly fishing destination guide for the Salinas River watershed"
+      },
+      "es": {
+        "name": "California Fly Fisher: Guía de destino de pesca con mosca para la cuenca del río Salinas"
+      }
+    }
+  },
+  {
+    "url": "https://salinasvalleyflyfishing.org/salinas-valley-flyfishers-on-the-water/",
+    "translate": {
+      "en": {
+        "name": "Salinas Valley Fly Fishers: Community fishing reports and trip logs from local fly fishing experts on the Salinas River"
+      },
+      "es": {
+        "name": "Salinas Valley Fly Fishers: Informes de pesca comunitarios y registros de viajes de expertos locales en pesca con mosca en el río Salinas"
+      }
+    }
+  },
+  {
+    "url": "https://guidesly.com/fishing/waterbodies/Salinas-River-California",
+    "translate": {
+      "en": {
+        "name": "Guidesly: Salinas River fishing guide with species information including striped bass and largemouth bass"
+      },
+      "es": {
+        "name": "Guidesly: Guía de pesca del río Salinas con información de especies incluyendo lubina rayada y lubina de boca grande"
+      }
+    }
+  }
+]

--- a/src/_data/locales/en.json
+++ b/src/_data/locales/en.json
@@ -115,6 +115,9 @@
     "detectedOn": "Detected on",
     "photosTitle": "Photos from the river",
     "photosPreamble": "Photos taken along the Salinas River, tagged with the nearest access point and water flow data for that day.",
-    "nearAccessPoint": "Near"
+    "nearAccessPoint": "Near",
+    "externalWebsites": "External websites",
+    "externalWebsitesNearAccessPoints": "Near",
+    "externalWebsitesRelatedTrips": "Related trips"
   }
 }

--- a/src/_data/locales/es.json
+++ b/src/_data/locales/es.json
@@ -115,6 +115,9 @@
     "detectedOn": "Detectado el",
     "photosTitle": "Fotos del río",
     "photosPreamble": "Fotos tomadas a lo largo del río Salinas, etiquetadas con el punto de acceso más cercano y los datos de caudal de ese día.",
-    "nearAccessPoint": "Cerca de"
+    "nearAccessPoint": "Cerca de",
+    "externalWebsites": "Sitios web externos",
+    "externalWebsitesNearAccessPoints": "Cerca de",
+    "externalWebsitesRelatedTrips": "Viajes relacionados"
   }
 }

--- a/src/en/overview/usage.webc
+++ b/src/en/overview/usage.webc
@@ -8,4 +8,4 @@ breadcrumbs:
   - name: Overview
     link: /overview
 ---
-<page-usage :@detections="detections" :@usage-photos="usagePhotos" :@access-points="accessPoints"></page-usage>
+<page-usage :@detections="detections" :@usage-photos="usagePhotos" :@access-points="accessPoints" :@trips="trips" :@external-usage-proofs="externalUsageProofs"></page-usage>

--- a/src/es/overview/usage.webc
+++ b/src/es/overview/usage.webc
@@ -8,4 +8,4 @@ breadcrumbs:
   - name: Visión general
     link: /overview
 ---
-<page-usage :@detections="detections" :@usage-photos="usagePhotos" :@access-points="accessPoints"></page-usage>
+<page-usage :@detections="detections" :@usage-photos="usagePhotos" :@access-points="accessPoints" :@trips="trips" :@external-usage-proofs="externalUsageProofs"></page-usage>


### PR DESCRIPTION
## Summary

- Adds `src/_data/external-usage-proofs.json` — a curated list of external websites documenting river usage, each with a URL, date, bilingual name, and optional access point and trip slugs
- Adds a new "External websites" section at the top of the River Usage page (`/en/overview/usage/` and `/es/overview/usage/`) listing entries in reverse chronological order
- Entries link to related access points and trips by slug
- Fully bilingual — all strings go through `t()` / `l()` / `formatDate()` filters; Spanish translations included in the data file
- Adds `body { background-color: #ffffff }` to fix dark-canvas rendering in non-browser environments
- Adds `.claude/CLAUDE.md` documenting the project, i18n system, and development conventions

## Test plan

- [ ] Visit `/en/overview/usage/` — "External websites" section appears above "Photos from the river" with links, dates, and access point/trip tags
- [ ] Visit `/es/overview/usage/` — section heading reads "Sitios web externos", entry names and dates are in Spanish
- [ ] Entries without a date render without errors
- [ ] Entries without `accessPoints` or `trips` render without the "Near" / "Related trips" lines
- [ ] Access point and trip links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)