### PR TITLE
Update dam release schedule to 2026 provisional data

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,8 +3,8 @@
   "configurations": [
     {
       "name": "eleventy-dev",
-      "runtimeExecutable": "npx",
-      "runtimeArgs": ["tsx", "./node_modules/.bin/eleventy", "--config=eleventy.config.ts", "--serve", "--port=8082"],
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev", "--", "--port=8082"],
       "port": 8082,
       "autoPort": false
     }

--- a/src/en/overview/dam-release.md
+++ b/src/en/overview/dam-release.md
@@ -10,25 +10,25 @@ breadcrumbs:
 
 # Nacimiento and San Antonio release schedule
 
-Most of the water-related activities on the southern Salinas depend on dam release from the Nacimiento reservoir, and to a lesser extent the San Antonio reservoir. While you can get [real-time flow information from the USGS](https://waterdata.usgs.gov/nwis/uv?site_no=11150500), if you are planning a trip in the future you should consider the following dam release sechedule.
+Most of the water-related activities on the southern Salinas depend on dam release from the Nacimiento reservoir, and to a lesser extent the San Antonio reservoir. While you can get [real-time flow information from the USGS](https://waterdata.usgs.gov/nwis/uv?site_no=11150500), if you are planning a trip in the future you should consider the following dam release schedule.
 
-This was the **release schedule for 2025**. We expect a provisoinal release schedule to be released around March 2026.
+This is the **provisional release schedule for 2026**.
 
 | Month     | Combined release (<abbr title="Cubic-feet per second">cfs</abbr>) |
 | --------- | ----------------------------------------------------------------- |
-| January   | 73                                                                |
-| February  | 172                                                               |
-| March     | 218                                                               |
-| April     | 380                                                               |
-| May       | 409                                                               |
-| June      | 488                                                               |
-| July      | 600                                                               |
-| August    | 638                                                               |
-| September | 470                                                               |
-| October   | 220                                                               |
+| January   | 70                                                                |
+| February  | 72                                                                |
+| March     | 89                                                                |
+| April     | 301                                                               |
+| May       | 440                                                               |
+| June      | 510                                                               |
+| July      | 564                                                               |
+| August    | 623                                                               |
+| September | 467                                                               |
+| October   | 212                                                               |
 | November  | 70                                                                |
 | December  | 70                                                                |
 
-<small>From the [Monterey County Water Resources Agency 2025 provisional release schedule](https://monterey.legistar.com/gateway.aspx?M=F&ID=fea9a761-9345-495c-8476-050c65fe7e81.pdf). CFS is defined as "Mean daily flow for the month."</small>
+<small>From the [Monterey County Water Resources Agency 2026 draft release schedule](https://monterey.legistar.com/View.ashx?M=F&ID=15390538&GUID=088D3BDF-260E-4E35-B6C8-B311879E8B5A). CFS is defined as "Mean daily flow for the month." This is provisional data dated 4/14/2026 and is subject to change.</small>
 
 The water flows down the Nacimiento and San Antonio Rivers, both of which join up with the Salinas just south of the town of Bradley. When the [river guage at Bradley](https://waterdata.usgs.gov/nwis/uv?site_no=11150500) is over 400 cfs (it is currently {{guages.bradley.cfs}}), the water can sometimes reach beyond King City.

--- a/src/es/overview/dam-release.md
+++ b/src/es/overview/dam-release.md
@@ -12,23 +12,23 @@ breadcrumbs:
 
 La mayoría de las actividades relacionadas con el agua en el sur del Salinas dependen de la descarga de la presa del lago Nacimiento. Sin la presa, el río Salinas sólo tendría caudal durante la estación húmeda, entre diciembre y mayo. Aunque puede obtener [información sobre el caudal en tiempo real del USGS](https://waterdata.usgs.gov/nwis/uv?site_no=11150500), si está planeando un viaje en el futuro debe tener en cuenta el calendario de desembalse de la presa.
 
-Este fue el **calendario de lanzamientos para 2025**. Esperamos publicar un calendario provisional de lanzamientos alrededor de marzo de 2026.
+Este es el **calendario provisional de desembalses para 2026**.
 
 | Mes        | Liberación combinada (<abbr title="Pies cúbicos por segundo">cfs</abbr>) |
 | ---------- | ------------------------------------------------------------------------ |
-| Enero      | 73                                                                       |
-| Febrero    | 172                                                                      |
-| Marzo      | 218                                                                      |
-| Abril      | 380                                                                      |
-| Mayo       | 409                                                                      |
-| Junio      | 488                                                                      |
-| Julio      | 600                                                                      |
-| Agosto     | 638                                                                      |
-| Septiembre | 470                                                                      |
-| Octubre    | 220                                                                      |
+| Enero      | 70                                                                       |
+| Febrero    | 72                                                                       |
+| Marzo      | 89                                                                       |
+| Abril      | 301                                                                      |
+| Mayo       | 440                                                                      |
+| Junio      | 510                                                                      |
+| Julio      | 564                                                                      |
+| Agosto     | 623                                                                      |
+| Septiembre | 467                                                                      |
+| Octubre    | 212                                                                      |
 | Noviembre  | 70                                                                       |
 | Diciembre  | 70                                                                       |
 
-<small>Del [calendario de desembalses para 2025 de la Agencia de Recursos Hídricos del Condado de Monterey](https://monterey.legistar.com/gateway.aspx?M=F&ID=fea9a761-9345-495c-8476-050c65fe7e81.pdf). CFS se define como "caudal medio diario del mes".</small>
+<small>Del [calendario de desembalses preliminar para 2026 de la Agencia de Recursos Hídricos del Condado de Monterey](https://monterey.legistar.com/View.ashx?M=F&ID=15390538&GUID=088D3BDF-260E-4E35-B6C8-B311879E8B5A). CFS se define como "caudal medio diario del mes." Estos son datos provisionales con fecha del 14/4/2026 y están sujetos a cambios.</small>
 
 El agua baja por el río Nacimiento y se une al Salinas justo al sur de la ciudad de Bradley. Cuando el [medidor fluvial en Bradley](https://waterdata.usgs.gov/nwis/uv?site_no=11150500) supera los 400 pcs (actualmente es {{guages.bradley.cfs}}), el agua puede llegar a veces más allá de King City.


### PR DESCRIPTION
## Summary

- Updated the dam release schedule from 2025 to 2026 using the draft data from the Monterey County Water Resources Agency (dated 4/14/2026)
- Updated both English and Spanish pages with new combined release values and source link
- Added a note that the data is provisional and subject to change

## Details

Data sourced from the [2026 Draft Reservoir Release Schedule](https://monterey.legistar.com/View.ashx?M=F&ID=15390538&GUID=088D3BDF-260E-4E35-B6C8-B311879E8B5A). Key changes in combined release (cfs):

| Month | 2025 | 2026 |
|-------|------|------|
| Jan | 73 | 70 |
| Feb | 172 | 72 |
| Mar | 218 | 89 |
| Apr | 380 | 301 |
| May | 409 | 440 |
| Jun | 488 | 510 |
| Jul | 600 | 564 |
| Aug | 638 | 623 |
| Sep | 470 | 467 |
| Oct | 220 | 212 |
| Nov | 70 | 70 |
| Dec | 70 | 70 |

Also fixed a typo ("sechedule" → "schedule") and updated `.claude/launch.json` to use `npm run dev` for better worktree compatibility.

## Test plan

- [x] Verified English page renders correctly at `/en/overview/dam-release/`
- [x] Verified Spanish page renders correctly at `/es/overview/dam-release/`
- [x] Confirmed source link points to correct Legistar document
- [x] Confirmed provisional data disclaimer appears at bottom of table

🤖 Generated with [Claude Code](https://claude.com/claude-code)